### PR TITLE
Pause stream when disabling VAD

### DIFF
--- a/audio/vad.py
+++ b/audio/vad.py
@@ -141,6 +141,8 @@ class VADListener:
     def disable_vad(self) -> None:
         self._frames_to_skip = 0
         self._reset_buffers = True
+        if self._stream is not None and self._stream.is_active():
+            self._stream.stop_stream()
         self._vad_enabled.clear()
 
 


### PR DESCRIPTION
## Summary
- stop the PyAudio stream when VAD is disabled so recording pauses immediately

## Testing
- not run (audio hardware not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ccdf41c1ac83309b01b55bb055f4e4