### PR TITLE
Streamline Jetson dependency guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@ This project wires together three real-time components on the Jetson Orin Nano: 
 ```bash
 sudo apt update
 sudo apt install -y git curl python3-venv python3-dev build-essential \
-    libportaudio2 portaudio19-dev libasound-dev libsndfile1 \
-    libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
-    libfreetype6-dev libjpeg-dev libpng-dev
+    libportaudio2 portaudio19-dev libasound-dev \
+    libsdl2-dev libsdl2-image-dev libpng-dev
 ```
 - `pyaudio` (microphone I/O) depends on PortAudio/ALSA headers and libs.
 - `webrtcvad` and `pygame` expect development headers to build on aarch64.
-- `soundfile` needs `libsndfile1` for playback; `pygame` uses SDL2/FreeType/JPEG/PNG for rendering.
+- `pygame` uses SDL2 and libpng for rendering; install SDL mixer/TTF and image codecs only if your project needs them.
 
 If you plan to display over HDMI while logged in via SSH, also enable an X server on the Jetson desktop (`DISPLAY=:0` later).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ kokoro-onnx==0.4.9
 PyAudio==0.2.14
 pygame==2.6.1
 requests==2.32.3
-soundfile==0.13.0
 webrtcvad==2.0.10


### PR DESCRIPTION
## Summary
- trim the Jetson apt install instructions to the core runtime dependencies and point readers to optional SDL extras only when needed
- drop the unused soundfile pin from requirements to match the streamlined dependency guidance

## Testing
- not run (Jetson hardware not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd18fc5608833081707f2b3a3d8cc7